### PR TITLE
fix: Run uv in project-less mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,18 +31,12 @@ runs:
   using: "composite"
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.12"
-        python-version-file: "pyproject.toml"
+      uses: astral-sh/setup-uv@v6
 
     - name: Update SSM Parameter if needed
       shell: bash
       run: |
-        uv run ${{ github.action_path }}/ssm-parameter.py \
+        uv run --no-project ${{ github.action_path }}/ssm-parameter.py \
           --name "${{ inputs.name }}" \
           --value "${{ inputs.value }}" \
           --description "${{ inputs.description }}" \

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,7 +23,7 @@
       "draft": false,
       "prerelease": false,
       "pull-request-title-pattern": "chore${scope}: Release${component} v${version}",
-      "release-type": "simple"
+      "release-type": "python"
     }
   }
 }

--- a/ssm-parameter.py
+++ b/ssm-parameter.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "boto3>=1.34.136",
+# ]
+# ///
 
 import argparse
 import sys
@@ -39,11 +45,14 @@ def get_parameter_value(parameter_value: str | None, file_path: str | None) -> s
         str: The parameter value.
     """
 
-    if parameter_value is None and file_path is None:
+    if file_path is not None:
+        file_path = file_path.strip()
+
+    if parameter_value is None and not file_path:
         print("Either parameter_value or file_path must be provided")
         sys.exit(1)
 
-    if parameter_value is not None and file_path is not None:
+    if parameter_value is not None and file_path:
         print("Warning: Both parameter_value and file_path are provided, file_path will be prioritized")
 
     try:
@@ -97,8 +106,8 @@ def check_value_ssm_parameter(
     try:
         response = ssm.get_parameter(Name=parameter_name, WithDecryption=True)
         value = response["Parameter"]["Value"]
-        print("Parameter Exists, checking parameter details....")
-        print(f" - Parameter Value: {parameter_name}")
+        print("Parameter exists, checking parameter details....")
+        print(f" - Parameter value: {parameter_value}")
 
         response = ssm.describe_parameters(
             ParameterFilters=[
@@ -120,7 +129,7 @@ def check_value_ssm_parameter(
         if remote_type != parameter_type:
             raise ValueError(f"Cannot change parameter type from {remote_type} to {parameter_type}")
         elif value == parameter_value and description == parameter_description and tier == parameter_tier:
-            print(" - Verified parameter details are current.")
+            print(" - Parameter details are up to date.")
             return True
         else:
             print(" - Parameter details need to be updated.")


### PR DESCRIPTION
### TL;DR

Updated the GitHub Action to use uv's script dependencies feature instead of relying on a separate Python setup step.

### What changed?

- Updated from `astral-sh/setup-uv@v5` to `astral-sh/setup-uv@v6`
- Removed the separate `actions/setup-python@v5` step as it's no longer needed
- Added `--no-project` flag to the `uv run` command to avoid using project-level dependencies
- Added uv script dependencies declaration to `ssm-parameter.py` to specify Python version and boto3 dependency
- Changed release type from "simple" to "python" in release-please-config.json

### How to test?

1. Use this action in a workflow to update an SSM parameter
2. Verify that the action runs successfully without the separate Python setup step
3. Confirm that the SSM parameter is updated correctly in AWS

### Why make this change?

This change simplifies the action by leveraging uv's script dependencies feature, which allows specifying dependencies directly in the script file. This eliminates the need for a separate Python setup step, making the action more efficient and self-contained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated workflow to use the latest version of dependencies and improved environment setup.
	- Enhanced script metadata with Python version and dependency requirements.
	- Adjusted release configuration for better alignment with Python projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->