### PR TITLE
fix: Use uv script isolation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
     - name: Update SSM Parameter if needed
       shell: bash
       run: |
-        uv run --no-project ${{ github.action_path }}/ssm-parameter.py \
+        uv run --script ${{ github.action_path }}/ssm-parameter.py \
           --name "${{ inputs.name }}" \
           --value "${{ inputs.value }}" \
           --description "${{ inputs.description }}" \

--- a/ssm-parameter.py
+++ b/ssm-parameter.py
@@ -4,6 +4,9 @@
 # dependencies = [
 #     "boto3>=1.34.136",
 # ]
+#
+# [[tool.uv.index]]
+# url = "https://pypi.org/simple"
 # ///
 
 import argparse
@@ -48,11 +51,14 @@ def get_parameter_value(parameter_value: str | None, file_path: str | None) -> s
     if file_path is not None:
         file_path = file_path.strip()
 
-    if parameter_value is None and not file_path:
-        print("Either parameter_value or file_path must be provided")
+    if parameter_value is not None:
+        parameter_value = parameter_value.strip()
+
+    if not parameter_value and not file_path:
+        print("Error: Either parameter_value or file_path must be provided")
         sys.exit(1)
 
-    if parameter_value is not None and file_path:
+    if parameter_value and file_path:
         print("Warning: Both parameter_value and file_path are provided, file_path will be prioritized")
 
     try:
@@ -62,11 +68,11 @@ def get_parameter_value(parameter_value: str | None, file_path: str | None) -> s
         else:
             parameter_value = args.value
     except FileNotFoundError:
-        print(f"File not found: {file_path}")
+        print(f"Error: File not found: {file_path}")
         sys.exit(1)
 
     if parameter_value is None or parameter_value == "":
-        print("Parameter value or provided file path cannot be empty")
+        print("Error: Both parameter_value and file_path cannot be empty")
         sys.exit(1)
 
     return parameter_value

--- a/ssm-parameter.py.lock
+++ b/ssm-parameter.py.lock
@@ -1,0 +1,85 @@
+version = 1
+revision = 1
+requires-python = ">=3.12"
+
+[manifest]
+requirements = [{ name = "boto3", specifier = ">=1.34.136" }]
+
+[[package]]
+name = "boto3"
+version = "1.38.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/fa/3907a6f574172d34ec1d8f27d02cef82f1a218cc438bfb89c24c68f11b8f/boto3-1.38.9.tar.gz", hash = "sha256:71f6d43f5bc156cc904f8dde9a2801adb222b81724fb9129f8ff6e7b9331e853", size = 111778 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/b7/132e5950668ca9c5c53ee6b7658b80446db78df8c923f96c4d73d694ed59/boto3-1.38.9-py3-none-any.whl", hash = "sha256:a9f8642e84589e7787da0d5d146a14d1eb9e3a4029893c88d1b4e11654cf8014", size = 139900 },
+]
+
+[[package]]
+name = "botocore"
+version = "1.38.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/7f/8d376fe976f352875a670811de9cef7a6212c2bc8019a4aa9c284cfc1d06/botocore-1.38.9.tar.gz", hash = "sha256:53113040882192388e05edebee48d45c008fb4ba2739dc889ce09b2adc9e56e4", size = 13877998 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/39/a390efe23b6e3db08eda6082e4624f7b1b0aab139ad8520b98dc03e154d1/botocore-1.38.9-py3-none-any.whl", hash = "sha256:2d954d3d9a6c7f86fbfbeb164223996c24b7b7726682bace61f86a7e10b531e6", size = 13537742 },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256 },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/9e/73b14aed38ee1f62cd30ab93cd0072dec7fb01f3033d116875ae3e7b8b44/s3transfer-0.12.0.tar.gz", hash = "sha256:8ac58bc1989a3fdb7c7f3ee0918a66b160d038a147c7b5db1500930a607e9a1c", size = 149178 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/64/d2b49620039b82688aeebd510bd62ff4cdcdb86cbf650cc72ae42c5254a3/s3transfer-0.12.0-py3-none-any.whl", hash = "sha256:35b314d7d82865756edab59f7baebc6b477189e6ab4c53050e28c1de4d9cce18", size = 84773 },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680 },
+]


### PR DESCRIPTION
# Update uv command and improve error handling in SSM parameter action

This PR makes several improvements to the SSM parameter GitHub Action:

1. Updates the uv command from `--no-project` to `--script` flag in the action.yml file
2. Improves error handling in the SSM parameter script:
   - Adds proper stripping of parameter values
   - Enhances validation logic for parameter values and file paths
   - Adds "Error:" prefix to error messages for better visibility
3. Adds PyPI index configuration in the script header comments
4. Includes a lockfile for dependencies to ensure consistent installations

These changes make the action more robust and provide clearer error messages when something goes wrong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation and error handling for input parameters, ensuring clearer error messages with consistent "Error:" prefixes.
- **Style**
	- Enhanced code readability by refining input checks and updating warning/error messages.
- **Documentation**
	- Added a commented-out configuration snippet for a Python package index URL to assist with future configuration needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->